### PR TITLE
fix: add datadog sidecar container dependency ordering

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,44 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v2
+        id: github-app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ steps.github-app-token.outputs.token }}"
+
+      - name: Enable auto-merge for GitHub Actions updates
+        if: |
+          steps.metadata.outputs.package-ecosystem == 'github_actions' &&
+          (steps.metadata.outputs.update-type == 'version-update:semver-major' ||
+           steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+           steps.metadata.outputs.update-type == 'version-update:semver-patch')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ steps.github-app-token.outputs.token }}
+
+      - name: Enable auto-merge for Terraform patch updates
+        if: |
+          steps.metadata.outputs.package-ecosystem == 'terraform' &&
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ steps.github-app-token.outputs.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.0]() (2026-02-25)
+
+### Features
+
+* Add Dependabot auto-merge GitHub Actions workflow:
+  * Automatically merges Dependabot PRs for GitHub Actions updates (all semver types).
+  * Automatically merges Dependabot PRs for Terraform patch updates.
+
+### Bug Fixes
+
+* Fix Datadog sidecar container dependency ordering:
+  * Add explicit dependency on Datadog container to ensure it starts before the main application container.
+
 ## [2.0.1]() (2025-12-29)
 
 ### Fix Bugs

--- a/locals.tf
+++ b/locals.tf
@@ -108,6 +108,10 @@ locals {
         {
           containerName : "log_router"
           condition : "START"
+        },
+        {
+          containerName : "datadog"
+          condition : "START"
         }
       ] : [])
     },


### PR DESCRIPTION
## Summary

### Why
Datadog sidecar container needs to start before the main application container to ensure proper initialization and log collection. Without explicit dependency ordering, the main container may attempt to connect before Datadog is ready.

### What
- Add explicit `dependsOn` condition for Datadog container in ECS task definition (locals.tf)
- Add Dependabot auto-merge workflow for GitHub Actions and Terraform patch updates (.github/workflows/dependabot-automerge.yml)
- Update CHANGELOG.md to document version 2.1.0 release

### Solution
Added container dependency ordering using ECS `dependsOn` with `START` condition. This ensures Datadog sidecar initializes before the main container, following AWS best practices for multi-container task definitions.

## Types of Changes
- [x] 🕷 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 📝 Documentation (non-breaking change that doesn't change code behavior)

## Test Plan
- Pre-commit hooks validation passed (Terraform fmt and validate)
- ECS task definition structure verified
- No breaking changes to existing API

## Related Issues
Closes version 2.1.0 release preparation