### PR TITLE
feat: upgrade Lambda runtime to nodejs22.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.2.0]() (2026-03-01)
+
+### Features
+
+* Update Lambda runtime from `nodejs20.x` to `nodejs22.x`
+
 ## [2.1.0]() (2026-02-25)
 
 ### Features

--- a/notification.tf
+++ b/notification.tf
@@ -10,7 +10,7 @@ module "eventbridge-slack-notification" {
 
   lambda_source_file = "${path.module}/files/index.mjs"
   lambda_handler     = "index.handler"
-  lambda_runtime     = "nodejs20.x"
+  lambda_runtime     = "nodejs22.x"
 
   additional_iam_policy_arns = {
     lambda_ecs_policy = aws_iam_policy.lambda_ecs_policy[0].arn


### PR DESCRIPTION
## Summary

### Why
Node.js 20.x is approaching end-of-support. Node.js 22.x is the current LTS version with improved performance and security.

### What
- Updated `lambda_runtime` from `nodejs20.x` to `nodejs22.x` in `notification.tf`
- Added v2.2.0 changelog entry

### Solution
Direct runtime version bump passed to the eventbridge-slack-notification child module — no code changes needed.

## Types of Changes
- [x] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)

## Test Plan
- Verified `nodejs22.x` is a supported AWS Lambda runtime
- No breaking changes between Node.js 20 and 22 for the notification handler